### PR TITLE
Fixed mixed up event and session ids

### DIFF
--- a/android/src/main/java/com/google/android/apps/iosched/ui/SessionFeedbackFragment.java
+++ b/android/src/main/java/com/google/android/apps/iosched/ui/SessionFeedbackFragment.java
@@ -139,8 +139,8 @@ public class SessionFeedbackFragment extends Fragment {
         Matcher matcher = pattern.matcher(mSessionId);
 
         if (matcher.matches()) {
-            sessionId = matcher.group(1);
-            eventId = matcher.group(2);
+            eventId = matcher.group(1);
+            sessionId = matcher.group(2);
         }
 
         JZFeedback jzFeedback = new JZFeedback(overallMandatoryRating, relevantRating,


### PR DESCRIPTION
The eventId comes before the session id in the url that's used to extract the values
